### PR TITLE
Update SW naming and file caching logic

### DIFF
--- a/wp-sw-cache/lib/service-worker.js
+++ b/wp-sw-cache/lib/service-worker.js
@@ -1,9 +1,10 @@
 (function(self){
   var CACHE_PREFIX = '__wp-sw-cache::';
 
-  var CACHE_NAME = CACHE_PREFIX + $name;
-
+  var CACHE_NAME = CACHE_PREFIX + '$name';
   var CACHE_FILES = $files;
+
+  var debug = $debug;
 
   self.addEventListener('install', function(event) {
     // Perform install step:  loading each required file into cache
@@ -11,13 +12,15 @@
       caches.open(CACHE_NAME)
         .then(function(cache) {
           // Add all offline dependencies to the cache
-          console.log('[install] Caches opened, adding all core components ' +
-            'to cache');
+          if (debug) {
+            console.log('[install] Caches opened, adding all core components to cache');
+          }
           return cache.addAll(CACHE_FILES);
         })
         .then(function() {
-          console.log('[install] All required resources have been cached, ' +
-            'we\'re good!');
+          if (debug) {
+            console.log('[install] All required resources have been cached, we\'re good!');
+          }
           return self.skipWaiting();
         })
     );
@@ -34,13 +37,14 @@
       caches.match(lookupRequest)
         .then(function(response) {
           if (response) {
-            console.log(
-              '[fetch] Returning from ServiceWorker cache: ',
-              event.request.url
-            );
+            if (debug) {
+              console.log('[fetch] Returning from ServiceWorker cache: ', event.request.url);
+            }
             return response;
           }
-          console.error('[fetch] Cache miss! This should not happen. It implies problems caching.');
+          if (debug) {
+            console.error('[fetch] Cache miss! This should not happen. It implies problems caching.');
+          }
           return fetch(event.request);
         }
       )
@@ -72,14 +76,18 @@
   }
 
   self.addEventListener('activate', function(event) {
-    console.log('[activate] Activating ServiceWorker!');
+    if (debug) {
+      console.log('[activate] Activating ServiceWorker!');
+    }
 
     // Clean up old cache in the background
     caches.keys().then(function(cacheNames) {
       return Promise.all(
         cacheNames.map(function(cacheName) {
           if(cacheName.startsWith(CACHE_PREFIX) && cacheName != CACHE_NAME) {
-            console.log('[activate] Deleting out of date cache:', cacheName);
+            if (debug) {
+              console.log('[activate] Deleting out of date cache:', cacheName);
+            }
             return caches.delete(cacheName);
           }
         })
@@ -87,7 +95,9 @@
     });
 
     // Calling claim() to force a "controllerchange" event on navigator.serviceWorker
-    console.log('[activate] Claiming this ServiceWorker!');
+    if (debug) {
+      console.log('[activate] Claiming this ServiceWorker!');
+    }
     event.waitUntil(self.clients.claim());
   });
 })(self);

--- a/wp-sw-cache/wp-sw-cache-db.php
+++ b/wp-sw-cache/wp-sw-cache-db.php
@@ -3,7 +3,6 @@
 class SW_Cache_DB {
 
   private static $instance;
-  public static $cache_prefix = 'wp-sw-cache';
 
   public function __construct() {
   }
@@ -19,8 +18,9 @@ class SW_Cache_DB {
   public static function on_activate() {
     // Set default options.
     update_option('wp_sw_cache_enabled', false);
-    update_option('wp_sw_cache_name', self::$cache_prefix.'-'.time());
     update_option('wp_sw_cache_files', array());
+    SW_Cache_Main::update_version();
+    update_option('wp_sw_cache_debug', true);
   }
 
   public static function on_deactivate() {
@@ -30,6 +30,7 @@ class SW_Cache_DB {
     delete_option('wp_sw_cache_enabled');
     delete_option('wp_sw_cache_name');
     delete_option('wp_sw_cache_files');
+    delete_option('wp_sw_cache_debug');
   }
 
 }

--- a/wp-sw-cache/wp-sw-cache-main.php
+++ b/wp-sw-cache/wp-sw-cache-main.php
@@ -8,6 +8,7 @@ load_plugin_textdomain('wpswcache', false, dirname(plugin_basename(__FILE__)) . 
 
 class SW_Cache_Main {
   private static $instance;
+  public static $cache_prefix = 'wp-sw-cache';
 
   public function __construct() {
     if (get_option('wp_sw_cache_enabled')) {
@@ -21,18 +22,36 @@ class SW_Cache_Main {
     }
   }
 
+  public function update_version($name = '') {
+    if(!$name) {
+      $name = time();
+    }
+    update_option('wp_sw_cache_name', self::$cache_prefix.'-'.$name);
+  }
+
   public function write_sw() {
+
     $files = get_option('wp_sw_cache_files');
+    $file_keys = array();
     if(!$files) {
-        $files = array();
+      $files = array();
     }
     foreach($files as $index=>$file) {
-        $files[$index] = get_template_directory_uri().'/'.$file;
+      $tfile = get_template_directory().'/'.$file;
+
+      if(file_exists($tfile)) {
+        $file_keys[get_template_directory_uri().'/'.$file] = filemtime($tfile);
+      }
     }
 
+    $file_keys = array_keys($file_keys);
+    $name = md5(serialize($file_keys));
+    self::update_version($name);
+
     $contents = file_get_contents(dirname(__FILE__).'/lib/service-worker.js');
-    $contents = str_replace('$name', json_encode(get_option('wp_sw_cache_name')), $contents);
-    $contents = str_replace('$files', json_encode($files), $contents);
+    $contents = str_replace('$name', $name, $contents);
+    $contents = str_replace('$files', json_encode($file_keys), $contents);
+    $contents = str_replace('$debug', get_option('wp_sw_cache_debug') ? 'true' : 'false', $contents);
     echo $contents;
   }
 }


### PR DESCRIPTION
This PR makes the following changes:

*  The cache name is now based on a MD5 of a serialized key=>value (filepath=>filemtime) array and is now only calculated upon SW content creation, instead of upon settings saving.  I think this is the best (and only) time because a file may change between save and usage (for example, someone uploads a new version via FTP).

* I didn't use a `wp_hash` of file contents because if they cache a file that's massive, performance will take a dive.

*  I added a setting within admin for whether or not the SW can have `console` function calls.