### PR TITLE
Adding more efficient caching mechanism so entire caches aren't deleted for one file change

### DIFF
--- a/sw-tests.js
+++ b/sw-tests.js
@@ -8,6 +8,7 @@ var SW_TESTS = [
 // Import chai and sinon into the ServiceWorkerGlobalScope
 importScripts('/base/node_modules/chai/chai.js');
 importScripts('/base/node_modules/sinon/pkg/sinon.js');
+importScripts('/base/tests/service-worker/localforage.mock.js');
 
 // Setup mocha to be bdd and make chai.expect globally available
 self.assert = chai.assert;

--- a/tests/service-worker/localforage.mock.js
+++ b/tests/service-worker/localforage.mock.js
@@ -1,0 +1,19 @@
+localforage = {
+  createInstance: function() {
+    var storage = {};
+    return {
+      getItem: function(key) {
+        return Promise.resolve(storage[key]);
+      },
+      setItem: function(key, value) {
+        return Promise.resolve();
+      },
+      clear: function() {
+        Object.keys(storage).forEach(function(key) {
+          delete storage[key];
+        });
+        return Promise.resolve();
+      }
+    };
+  }
+};

--- a/tests/service-worker/test.js
+++ b/tests/service-worker/test.js
@@ -1,7 +1,35 @@
 describe('tests', function() {
   'use strict';
 
+  var cacheName = 'testCache';
+
+  // Needed to prevent SW from bombing on what needs to be replaced
+  self.$urls = {
+    'http://localhost/wp-content/themes/my-theme/script.js': '32942374293',
+    'http://localhost/wp-content/themes/my-theme/style.css': '997898326'
+  };
+  self.$debug = 1;
+
+  beforeEach(function() {
+    importScripts('/base/wp-sw-cache/lib/service-worker.js');
+  });
+
   it('This is a stub test', function() {
+    assert.strictEqual(true, true);
+  });
+
+  it('URLs which should be added to cache actually end up in cache and storage', function() {
+    // Simulates a basic install
+    assert.strictEqual(true, true);
+  });
+
+  it('A URL removed from the `urls` property removes unwanted URLs from cache and storage', function() {
+    // This is key to removing stale files from cache after an admin no longer wants a file cached
+    // Simulates a user caching files, going to admin to remove a file, and seeing that file removed from cache+storage
+    assert.strictEqual(true, true);
+  });
+
+  it('`shouldBeHandled` works properly', function() {
     assert.strictEqual(true, true);
   });
 

--- a/tests/test-sw.php
+++ b/tests/test-sw.php
@@ -14,14 +14,14 @@ class SW_Tests extends WP_UnitTestCase {
 
 	function test_file_must_exist() {
 		// Step 1:  Set the hash
-		$first_hash = get_option('wp_sw_cache_name');
+		$first_hash = get_option('wp_sw_cache_version');
 
 		// Step 2:  Rename file so to mock that the file has been deleted
 		rename(get_template_directory().'/style.css', get_template_directory().'/style.temp');
 
 		// Step 3:  Get hash
 		SW_Cache_Main::build_sw();
-		$second_hash = get_option('wp_sw_cache_name');
+		$second_hash = get_option('wp_sw_cache_version');
 
 		// Success means the hash was updated because the file was deleted
 		$this->assertTrue($first_hash != $second_hash);
@@ -33,11 +33,11 @@ class SW_Tests extends WP_UnitTestCase {
 	function test_unchanged_files_and_times_generates_same_hash() {
 		// Step 1:  Get hash
 		SW_Cache_Main::build_sw();
-		$first_hash = get_option('wp_sw_cache_name');
+		$first_hash = get_option('wp_sw_cache_version');
 
 		// Step 2:  Do nothing, get the hash again
 		SW_Cache_Main::build_sw();
-		$second_hash = get_option('wp_sw_cache_name');
+		$second_hash = get_option('wp_sw_cache_version');
 
 		// Success means the hashes are the same because nothing has changed
 		$this->assertTrue($first_hash === $second_hash);
@@ -46,7 +46,7 @@ class SW_Tests extends WP_UnitTestCase {
 	function test_file_changed_generates_new_hash() {
 		// Step 1:  Get hash
 		SW_Cache_Main::build_sw();
-		$first_hash = get_option('wp_sw_cache_name');
+		$first_hash = get_option('wp_sw_cache_version');
 
 		// Step 2:  Update a file's contents to nudge the modified time
 		$file_to_edit = get_template_directory().'/style.css';
@@ -55,7 +55,7 @@ class SW_Tests extends WP_UnitTestCase {
 
 		// Step 3:  Get the new hash
 		SW_Cache_Main::build_sw();
-		$second_hash = get_option('wp_sw_cache_name');
+		$second_hash = get_option('wp_sw_cache_version');
 
 		// Success means the hashes are different because a file has changed
 		$this->assertTrue($first_hash !== $second_hash);
@@ -64,7 +64,7 @@ class SW_Tests extends WP_UnitTestCase {
 	function test_changed_file_list_generates_new_hash() {
 		// Step 1:  Get hash
 		SW_Cache_Main::build_sw();
-		$first_hash = get_option('wp_sw_cache_name');
+		$first_hash = get_option('wp_sw_cache_version');
 
 		// Step 2:  Remove the last item from the list
 		$files = get_option('wp_sw_cache_files');
@@ -73,7 +73,7 @@ class SW_Tests extends WP_UnitTestCase {
 
 		// Step 3:  Get the new hash
 		SW_Cache_Main::build_sw();
-		$second_hash = get_option('wp_sw_cache_name');
+		$second_hash = get_option('wp_sw_cache_version');
 
 		// Success means the hashes are different because a file has changed
 		$this->assertTrue($first_hash !== $second_hash);

--- a/wp-sw-cache/wp-sw-cache-admin.php
+++ b/wp-sw-cache/wp-sw-cache-admin.php
@@ -65,7 +65,7 @@ class SW_Cache_Admin {
   }
 
   function show_switch_theme_message() {
-    echo '<div class="update-nag"><p>',  __('You\'ve changed themes; please update your WP ServiceWorker Cache options.', 'swpswcache'), '</p></div>';
+    echo '<div class="update-nag"><p>',  sprintf(__('You\'ve changed themes; please update your <a href="%s">WP ServiceWorker Cache options</a>.', 'swpswcache'), admin_url('options-general.php?page=wp-sw-cache-options')), '</p></div>';
   }
 
   function determine_file_recommendation($file_info, $all_files) {
@@ -145,7 +145,7 @@ class SW_Cache_Admin {
     </div>
   <?php } ?>
 
-  <h1><?php _e('WordPress Service Worker Cache', 'wpswcache'); ?> (<?php echo SW_Cache_Main::$cache_prefix; ?>)</h1>
+  <h1><?php _e('WordPress Service Worker Cache', 'wpswcache'); ?></h1>
 
   <p><?php _e('WordPress Service Worker Cache is a utility that harnesses the power of the <a href="https://serviceworke.rs" target="_blank">ServiceWorker API</a> to cache frequently used assets for the purposes of performance and offline viewing.'); ?></p>
 
@@ -166,12 +166,6 @@ class SW_Cache_Admin {
         <input type="checkbox" name="wp_sw_cache_debug" id="wp_sw_cache_debug" value="1" <?php if(get_option('wp_sw_cache_debug')) echo 'checked'; ?> />
       </td>
     </tr>
-    <tr>
-      <th scope="row"><label for="wp_sw_cache_name"><?php _e('Current Cache Name', 'wpswcache'); ?></label></th>
-      <td>
-        <em><?php echo get_option('wp_sw_cache_name'); ?></em>
-      </td>
-    </tr>
     </table>
 
     <h2><?php _e('Theme Files to Cache', 'wpswcache'); ?> (<code><?php echo get_template(); ?></code>)</h2>
@@ -182,7 +176,6 @@ class SW_Cache_Admin {
       <button type="button" class="button button-primary wp-sw-cache-suggest-file" data-suggested-text="<?php echo esc_attr__('Files Suggested: '); ?>"><?php _e('Suggest Files'); ?> <span>(<?php _e('beta'); ?>)</span></button>
     </p>
 
-    <?php /* <pre><?php print_r($selected_files); ?></pre> */ ?>
     <div class="wp-sw-cache-file-list">
       <?php
         $template_abs_path = get_template_directory();
@@ -268,7 +261,7 @@ class SW_Cache_Admin {
 
   <h2>Clear Caches</h2>
   <p><?php _e('Click the button below to clear any caches created by this plugin.'); ?></p>
-  <button type="button" class="button button-primary wp-sw-cache-clear-caches-button" data-cleared-text="<?php echo esc_attr('Caches cleared: '); ?>"><?php _e('Clear Caches'); ?></button>
+  <button type="button" class="button button-primary wp-sw-cache-clear-caches-button" data-cleared-text="<?php echo esc_attr('Cache Cleared!'); ?>"><?php _e('Clear Local Cache'); ?></button>
 
 </div>
 
@@ -321,6 +314,7 @@ class SW_Cache_Admin {
 </style>
 
 <script type="text/javascript">
+
   jQuery('.wp-sw-cache-suggest-file').on('click', function() {
     // TODO:  More advanced logic
 
@@ -355,7 +349,7 @@ class SW_Cache_Admin {
       return Promise.all(
         cacheNames.map(function(cacheName) {
 
-          if(cacheName.indexOf('<?php echo SW_Cache_Main::$cache_prefix; ?>') != -1) {
+          if(cacheName === '<?php echo SW_Cache_Main::$cache_name; ?>') {
             console.log('Clearing cache: ', cacheName);
             clearedCounter++;
             return caches.delete(cacheName);

--- a/wp-sw-cache/wp-sw-cache-db.php
+++ b/wp-sw-cache/wp-sw-cache-db.php
@@ -30,7 +30,7 @@ class SW_Cache_DB {
 
   public static function on_uninstall() {
     delete_option('wp_sw_cache_enabled');
-    delete_option('wp_sw_cache_name');
+    delete_option('wp_sw_cache_version');
     delete_option('wp_sw_cache_files');
     delete_option('wp_sw_cache_debug');
   }

--- a/wp-sw-cache/wp-sw-cache-main.php
+++ b/wp-sw-cache/wp-sw-cache-main.php
@@ -9,7 +9,7 @@ load_plugin_textdomain('wpswcache', false, dirname(plugin_basename(__FILE__)) . 
 
 class SW_Cache_Main {
   private static $instance;
-  public static $cache_prefix = 'wp-sw-cache';
+  public static $cache_name = '__wp-sw-cache';
 
   public function __construct() {
     if (get_option('wp_sw_cache_enabled')) {
@@ -27,7 +27,8 @@ class SW_Cache_Main {
     if(!$name) {
       $name = time();
     }
-    update_option('wp_sw_cache_name', self::$cache_prefix.'-'.$name);
+    update_option('wp_sw_cache_version', $name);
+    return $name;
   }
 
   public static function build_sw() {
@@ -42,27 +43,26 @@ class SW_Cache_Main {
     }
 
     // Will contain items like 'style.css' => {filemtime() of style.css}
-    $file_keys = array();
+    $urls = array();
 
     // Ensure that every file directed to be cached still exists
     foreach($files as $index=>$file) {
       $tfile = get_template_directory().'/'.$file;
       if(file_exists($tfile)) {
         // Use file's last change time in name hash so the SW is updated if any file is updated
-        $file_keys[get_template_directory_uri().'/'.$file] = filemtime($tfile);
+        $urls[get_template_directory_uri().'/'.$file] = (string)filemtime($tfile);
       }
     }
 
     // Serialize the entire array so we match file with time
     // This will catch file updates done outside of admin (like updating via FTP)
-    $name = md5(serialize($file_keys));
-    self::update_version($name);
+    $version = self::update_version(md5(serialize($urls)));
 
     // Template content into the JS file
     $contents = file_get_contents(dirname(__FILE__).'/lib/service-worker.js');
-    $contents = str_replace('$name', $name, $contents);
-    $contents = str_replace('$files', json_encode(array_keys($file_keys)), $contents);
-    $contents = str_replace('$debug', get_option('wp_sw_cache_debug') ? 'true' : 'false', $contents);
+    $contents = str_replace('$name', self::$cache_name, $contents);
+    $contents = str_replace('$urls', json_encode($urls), $contents);
+    $contents = str_replace('$debug', (string)get_option('wp_sw_cache_debug'), $contents);
     return $contents;
   }
 


### PR DESCRIPTION
The problem with the current version of wp-sw-cache is that deletes an entire cache when only one file/url changes, which isn't good.  This update checks served hashes against localforage hashes and only updates the stuff that has changed.