### PR TITLE
Output SW no matter if disabled or enabled.

### DIFF
--- a/tests/service-worker/test.js
+++ b/tests/service-worker/test.js
@@ -7,8 +7,8 @@ describe('tests', function() {
   beforeEach(function(done) {
     // Needed to prevent SW from bombing on what needs to be replaced
     self.$urls = {
-      'http://localhost:9876/socket.io/socket.io.js': '328947234',
-      'http://localhost:9876/karma.js': '32897324923'
+      'http://localhost:9876/socket.io/socket.io.js': '1111',
+      'http://localhost:9876/karma.js': '2222'
     };
     self.$debug = 1;
 
@@ -98,7 +98,7 @@ describe('tests', function() {
   it('Debug option works properly', function() {
     // We don't want to muddle up the user's console if they option isn't on
     console.log = console.warn = sinon.spy();
-    
+
     wpSwCache.debug = false;
     wpSwCache.log('Hello');
     assert.equal(console.log.callCount, 0);

--- a/tests/test.php
+++ b/tests/test.php
@@ -70,20 +70,6 @@ class SW_Tests extends WP_UnitTestCase {
 		update_option('wp_sw_cache_files', $files);
 	}
 
-	function test_disabled_plugin_returns_nothing() {
-		// Step 1:  Disable the plugin
-		update_option('wp_sw_cache_enabled', false);
-
-		// Step 2:  Get the SW output, which should be nothing
-		$sw_output = SW_Cache_Main::build_sw();
-
-		// Success is no output because the plugin is disabled
-		$this->assertTrue($sw_output === '');
-
-		// Cleanup:  re-enable the plugin
-		update_option('wp_sw_cache_enabled', true);
-	}
-
 	function test_update_runs_on_version_mismatch() {
 		$old_version = '0.0.0';
 		update_option('wp_sw_cache_version', $old_version);

--- a/wp-sw-cache/wp-sw-cache-main.php
+++ b/wp-sw-cache/wp-sw-cache-main.php
@@ -10,9 +10,7 @@ class SW_Cache_Main {
   public static $cache_name = '__wp-sw-cache';
 
   public function __construct() {
-    if (get_option('wp_sw_cache_enabled')) {
-      WP_SW_Manager::get_manager()->sw()->add_content(array($this, 'write_sw'));
-    }
+    WP_SW_Manager::get_manager()->sw()->add_content(array($this, 'write_sw'));
   }
 
   public static function init() {
@@ -23,25 +21,23 @@ class SW_Cache_Main {
   }
 
   public static function build_sw() {
-    // Return nothing if the plugin is disabled
-    if(!get_option('wp_sw_cache_enabled')) {
-      return '';
-    }
-
-    $files = get_option('wp_sw_cache_files');
-    if(!$files) {
-      $files = array();
-    }
-
     // Will contain items like 'style.css' => {filemtime() of style.css}
     $urls = array();
 
-    // Ensure that every file directed to be cached still exists
-    foreach($files as $index=>$file) {
-      $tfile = get_template_directory().'/'.$file;
-      if(file_exists($tfile)) {
-        // Use file's last change time in name hash so the SW is updated if any file is updated
-        $urls[get_template_directory_uri().'/'.$file] = (string)filemtime($tfile);
+    // Get files and validate they are of proper type
+    $files = get_option('wp_sw_cache_files');
+    if(!$files || !is_array($files)) {
+      $files = array();
+    }
+
+    // Ensure that every file requested to be cached still exists
+    if(get_option('wp_sw_cache_enabled')) {
+      foreach($files as $index => $file) {
+        $tfile = get_template_directory().'/'.$file;
+        if(file_exists($tfile)) {
+          // Use file's last change time in name hash so the SW is updated if any file is updated
+          $urls[get_template_directory_uri().'/'.$file] = (string)filemtime($tfile);
+        }
       }
     }
 


### PR DESCRIPTION
If the plugin is activated but disabled, we don't want the SW to serve real stuff up; this update essentially clears cache and caches a tiny stub file to ensure the SW is installed properly.